### PR TITLE
Ensure importlib dependency is met

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,13 @@
 
 from distutils.core import setup
 
+INSTALL_REQUIRES = []
+
+try:
+    import importlib
+except ImportError:
+    INSTALL_REQUIRES.append('importlib')
+
 setup(name='straight.plugin',
     version='1.3',
     description='A simple namespaced plugin facility',
@@ -9,6 +16,7 @@ setup(name='straight.plugin',
     author_email='ironfroggy@gmail.com',
     url='https://github.com/ironfroggy/straight.plugin',
     packages=['straight', 'straight.plugin'],
+    install_requires=INSTALL_REQUIRES,
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
`straight.plugin` uses `importlib`, which is only present in the standard library since Python 2.7/3.1.  This change adds a dependency on `importlib` when it's not present to support other Python versions.

``` pycon
Python 2.6 (r26:66714, Jun  1 2012, 11:16:26) 
[GCC 4.6.3] on linux3
Type "help", "copyright", "credits" or "license" for more information.
>>> import straight.plugin
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/alan/.pythonbrew/venvs/Python-2.6/PygOut-py2.6/lib/python2.6/site-packages/straight/plugin/__init__.py", line 1, in <module>
    from straight.plugin import loaders
  File "/home/alan/.pythonbrew/venvs/Python-2.6/PygOut-py2.6/lib/python2.6/site-packages/straight/plugin/loaders.py", line 6, in <module>
    from importlib import import_module
ImportError: No module named importlib
```
