### PR TITLE
Add a MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.rst
+include LICENSE
+include AUTHORS
+include tests.py
+graft test-packages
+graft doc


### PR DESCRIPTION
While updating the Fedora package I realize that something had disappeared since the last version I had (which I must say was pretty old). And they were important things like the LICENSE file or the README.

With the MANIFEST.in we can bring them back, also include the AUTHORS file and even re-include the tests which I always something nice to include.
