### PR TITLE
Added static file helper

### DIFF
--- a/straight/plugin/manager.py
+++ b/straight/plugin/manager.py
@@ -1,3 +1,5 @@
+import os
+
 class PluginManager(object):
 
     def __init__(self, plugins):
@@ -59,4 +61,11 @@ class PluginManager(object):
             if r is not None:
                 first_arg = r
         return r
+
+    def findFile(self, filename):
+        paths = set([os.path.dirname(p.__file__) for p in self._plugins])
+        for path in paths:
+            full = os.path.join(path, filename)
+            if os.path.isfile(full):
+                return full
 

--- a/test-packages/media-package/testplugin/__init__.py
+++ b/test-packages/media-package/testplugin/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/test-packages/media-package/testplugin/foo.py
+++ b/test-packages/media-package/testplugin/foo.py
@@ -1,0 +1,2 @@
+def do(x):
+    return x + 1

--- a/tests.py
+++ b/tests.py
@@ -79,6 +79,20 @@ class ModuleLoaderTestCase(LoaderTestCaseMixin, unittest.TestCase):
     def test_plugin(self):
         assert self.loader.load('testplugin')[0].do(1) == 2
 
+class StaticFinderTestCase(LoaderTestCaseMixin, unittest.TestCase):
+
+    paths = (
+        os.path.join(os.path.dirname(__file__), 'test-packages', 'media-package'),
+    )
+    
+    def setUp(self):
+        self.loader = loaders.ModuleLoader()
+        super(StaticFinderTestCase, self).setUp()
+    
+    def test_load(self):
+        modules = self.loader.load('testplugin')
+        self.assertIsNotNone(modules.findFile('templates/bar.html'))
+        self.assertIsNone(modules.findFile('templates/err.html'))
 
 class ImpliedNamespaceModuleTestCase(LoaderTestCaseMixin, unittest.TestCase):
 


### PR DESCRIPTION
Example usage test-case:

```
class StaticFinderTestCase(LoaderTestCaseMixin, unittest.TestCase):

    paths = (
        os.path.join(os.path.dirname(__file__), 'test-packages', 'media-package'),
    )

    def setUp(self):
        self.loader = loaders.ModuleLoader()
        super(StaticFinderTestCase, self).setUp()

    def test_load(self):
        modules = self.loader.load('testplugin')
        self.assertIsNotNone(modules.findFile('templates/bar.html'))
        self.assertIsNone(modules.findFile('templates/err.html'))
```
