### PR TITLE
Standardise package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     INSTALL_REQUIRES.append('importlib')
 
-setup(name='straight.plugin',
+setup(name='straight_plugin',
     version='1.4.1',
     description='A simple namespaced plugin facility',
     author='Calvin Spealman',


### PR DESCRIPTION
Fixes: #26

This is the super-easy part, but I thought I'd make the PR anyway, mostly as a token gesture.

The Right Thing to do for the harder part is probably to fix a separate PyPi compatibility issue, where it doesn't display the README file, and then use a separate commit on a "deprecated" branch modifying that README to point people to the new package.

I think the following code in setup.py should fix the README issue, but I want to avoid attempting that since I don't have admin access to the pypi package for testing and quickly fixing if it's borked :)

```
# read the contents of your README file
from os import path

this_directory = path.abspath(path.dirname(__file__))

with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
    long_description = f.read()

setup(
    ...
    long_description=long_description,
    long_description_content_type='text/x-rst'
    ...
)
```
