### PR TITLE
Remove the import of imp.find_module.

### DIFF
--- a/straight/plugin/loaders.py
+++ b/straight/plugin/loaders.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 from functools import lru_cache
-from imp import find_module
 from importlib import import_module
 
 from straight.plugin.manager import PluginManager


### PR DESCRIPTION
Usage of find_module has been replaced by importlib.

The imp module is going to be removed in python 3.12